### PR TITLE
Add the .envrc file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export GOPATH=$GOPATH:$PWD/vendor:$PWD


### PR DESCRIPTION
* This allows me to use `gb` with the go-plus Atom plugin.